### PR TITLE
Automatically sync definitions from AK with upsert

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,11 +22,17 @@ repos:
       - id: ruff-format
   - repo: local
     hooks:
-    -   id: validate-schema
+      - id: validate-schema
         name: validate schema
         entry: sh -c './script/validate --file_pairs schemas/schema_decision_tree.json:decision-tree.yaml schemas/schema_definitions.json:definitions.yaml'
         language: python
         additional_dependencies: [jsonschema, pyyaml]
+        pass_filenames: false
+        always_run: true
+      - id: check-definitions-sync
+        name: Check if definitions are in sync with Algoritmekader
+        entry: ./script/sync --mode compare
+        language: script
         pass_filenames: false
         always_run: true
 

--- a/definitions.yaml
+++ b/definitions.yaml
@@ -1,219 +1,528 @@
 definitions:
 - term: aanbieder
-  definition: "Een natuurlijke of rechtspersoon, overheidsinstantie, agentschap of ander orgaan die/dat een AI-systeem of een AI-model voor algemene doeleinden ontwikkelt of laat ontwikkelen en dat systeem of model in de handel brengt of het AI-systeem in gebruik stelt onder de eigen naam of merk, al dan niet tegen betaling."
+  definition: Een natuurlijke of rechtspersoon, overheidsinstantie, agentschap of
+    ander orgaan die/dat een AI-systeem of een AI-model voor algemene doeleinden ontwikkelt
+    of laat ontwikkelen en dat systeem of model in de handel brengt of het AI-systeem
+    in gebruik stelt onder de eigen naam of merk, al dan niet tegen betaling.
 - term: aanbieders
-  definition: "Een natuurlijke of rechtspersoon, overheidsinstantie, agentschap of ander orgaan die/dat een AI-systeem of een AI-model voor algemene doeleinden ontwikkelt of laat ontwikkelen en dat systeem of model in de handel brengt of het AI-systeem in gebruik stelt onder de eigen naam of merknaam, al dan niet tegen betaling."
+  definition: Een natuurlijke of rechtspersoon, overheidsinstantie, agentschap of
+    ander orgaan die/dat een AI-systeem of een AI-model voor algemene doeleinden ontwikkelt
+    of laat ontwikkelen en dat systeem of model in de handel brengt of het AI-systeem
+    in gebruik stelt onder de eigen naam of merknaam, al dan niet tegen betaling.
 - term: aanbieder verder in de AI-waardeketen
-  definition: "Een aanbieder van een AI-systeem, met inbegrip van een AI-systeem voor algemene doeleinden, waarin een AI-model is geïntegreerd, ongeacht of het AI-model door hemzelf wordt verstrekt en verticaal geïntegreerd is of door een andere entiteit wordt aangeboden op basis van contractuele betrekkingen."
+  definition: Een aanbieder van een AI-systeem, met inbegrip van een AI-systeem voor
+    algemene doeleinden, waarin een AI-model is geïntegreerd, ongeacht of het AI-model
+    door hemzelf wordt verstrekt en verticaal geïntegreerd is of door een andere entiteit
+    wordt aangeboden op basis van contractuele betrekkingen
 - term: aangemelde instantie
-  definition: "Een conformiteitsbeoordelingsinstantie die overeenkomstig de AI-verordening en andere relevante harmonisatiewetgeving van de Unie is aangemeld."
+  definition: Een conformiteitsbeoordelingsinstantie die overeenkomstig de AI-verordening
+    en andere relevante harmonisatiewetgeving van de Unie is aangemeld
 - term: aanmeldende autoriteit
-  definition: "De nationale autoriteit die verantwoordelijk is voor het opzetten en uitvoeren van de noodzakelijke procedures voor de beoordeling, aanwijzing en kennisgeving van de conformiteitsbeoordelingsinstanties en de monitoring hiervan."
-- term: AI-bureau
-  definition: "De taak van de Commissie waarbij zij bijdraagt aan de uitvoering van, de monitoring van en het toezicht op AI-systemen en AI-modellen voor algemene doeleinden, en AI-governance, als bepaald in het besluit van de Commissie van 24 januari 2024; verwijzingen in deze verordening naar het AI-bureau worden begrepen als verwijzingen naar de Commissie."
+  definition: De nationale autoriteit die verantwoordelijk is voor het opzetten en
+    uitvoeren van de noodzakelijke procedures voor de beoordeling, aanwijzing en kennisgeving
+    van de conformiteitsbeoordelingsinstanties en de monitoring hiervan
 - term: AI-geletterdheid
-  definition: "Vaardigheden, kennis en begrip die aanbieders, gebruiksverantwoordelijken en betrokken personen, rekening houdend met hun respectieve rechten en plichten in het kader van de de AI-verordening, in staat stellen met kennis van zaken AI-systemen in te zetten en zich bewuster te worden van de kansen en risico’s van AI en de mogelijke schade die zij kan veroorzaken."
+  definition: vaardigheden, kennis en begrip die aanbieders, gebruiksverantwoordelijken
+    en betrokken personen, rekening houdend met hun respectieve rechten en plichten
+    in het kader van de de AI-verordening, in staat stellen met kennis van zaken AI-systemen
+    in te zetten en zich bewuster te worden van de kansen en risico’s van AI en de
+    mogelijke schade die zij kan veroorzaken
 - term: AI-model voor algemene doeleinden
-  definition: "Een AI-model, ook wanneer het is getraind met een grote hoeveelheid data met behulp van self-supervision op grote schaal, dat een aanzienlijk algemeen karakter vertoont en in staat is op competente wijze een breed scala aan verschillende taken uit te voeren, ongeacht de wijze waarop het model in de handel wordt gebracht, en dat kan worden geïntegreerd in een verscheidenheid aan systemen verder in de AI-waardeketen of toepassingen verder in de AI-waardeketen, met uitzondering van AI-modellen die worden gebruikt voor onderzoek, ontwikkeling of prototypingactiviteiten alvorens zij in de handel worden gebracht."
+  definition: Een AI-model, ook wanneer het is getraind met een grote hoeveelheid
+    data met behulp van self-supervision op grote schaal, dat een aanzienlijk algemeen
+    karakter vertoont en in staat is op competente wijze een breed scala aan verschillende
+    taken uit te voeren, ongeacht de wijze waarop het model in de handel wordt gebracht,
+    en dat kan worden geïntegreerd in een verscheidenheid aan systemen verder in de
+    AI-waardeketen of toepassingen verder in de AI-waardeketen, met uitzondering van
+    AI-modellen die worden gebruikt voor onderzoek, ontwikkeling of prototypingactiviteiten
+    alvorens zij in de handel worden gebracht.
 - term: AI-modellen voor algemene doeleinden
-  definition: "Een AI-model, ook wanneer het is getraind met een grote hoeveelheid data met behulp van self-supervision op grote schaal, dat een aanzienlijk algemeen karakter vertoont en in staat is op competente wijze een breed scala aan verschillende taken uit te voeren, ongeacht de wijze waarop het model in de handel wordt gebracht, en dat kan worden geïntegreerd in een verscheidenheid aan systemen verder in de AI-waardeketen of toepassingen verder in de AI-waardeketen, met uitzondering van AI-modellen die worden gebruikt voor onderzoek, ontwikkeling of prototypingactiviteiten alvorens zij in de handel worden gebracht."
+  definition: Een AI-model, ook wanneer het is getraind met een grote hoeveelheid
+    data met behulp van self-supervision op grote schaal, dat een aanzienlijk algemeen
+    karakter vertoont en in staat is op competente wijze een breed scala aan verschillende
+    taken uit te voeren, ongeacht de wijze waarop het model in de handel wordt gebracht,
+    en dat kan worden geïntegreerd in een verscheidenheid aan systemen verder in de
+    AI-waardeketen of toepassingen verder in de AI-waardeketen, met uitzondering van
+    AI-modellen die worden gebruikt voor onderzoek, ontwikkeling of prototypingactiviteiten
+    alvorens zij in de handel worden gebracht.
 - term: AI-systeem voor algemene doeleinden
-  definition: "Een AI-systeem dat is gebaseerd op een AI-model voor algemene doeleinden en dat verschillende doeleinden kan dienen, zowel voor direct gebruik als voor integratie in andere AI-systemen."
+  definition: Een AI-systeem dat is gebaseerd op een AI- model voor algemene doeleinden
+    en dat verschillende doeleinden kan dienen, zowel voor direct gebruik als voor
+    integratie in andere AI-systemen
 - term: AI-systeem
-  definition: "Een op een machine gebaseerd systeem dat is ontworpen om met verschillende niveaus van autonomie te werken en dat na het inzetten ervan aanpassingsvermogen kan vertonen, en dat, voor expliciete of impliciete doelstellingen, uit de ontvangen input afleidt hoe output te genereren zoals voorspellingen, inhoud, aanbevelingen of beslissingen die van invloed kunnen zijn op fysieke of virtuele omgevingen."
+  definition: Een op een machine gebaseerd systeem dat is ontworpen om met verschillende
+    niveaus van autonomie te werken en dat na het inzetten ervan aanpassingsvermogen
+    kan vertonen, en dat, voor expliciete of impliciete doelstellingen, uit de ontvangen
+    input afleidt hoe output te genereren zoals voorspellingen, inhoud, aanbevelingen
+    of beslissingen die van invloed kunnen zijn op fysieke of virtuele omgevingen.
 - term: AI-systemen
-  definition: "Een op een machine gebaseerd systeem dat is ontworpen om met verschillende niveaus van autonomie te werken en dat na het inzetten ervan aanpassingsvermogen kan vertonen, en dat, voor expliciete of impliciete doelstellingen, uit de ontvangen input afleidt hoe output te genereren zoals voorspellingen, inhoud, aanbevelingen of beslissingen die van invloed kunnen zijn op fysieke of virtuele omgevingen."
+  definition: Een op een machine gebaseerd systeem dat is ontworpen om met verschillende
+    niveaus van autonomie te werken en dat na het inzetten ervan aanpassingsvermogen
+    kan vertonen, en dat, voor expliciete of impliciete doelstellingen, uit de ontvangen
+    input afleidt hoe output te genereren zoals voorspellingen, inhoud, aanbevelingen
+    of beslissingen die van invloed kunnen zijn op fysieke of virtuele omgevingen.
 - term: AI-testomgeving voor regelgeving
-  definition: "Een door een bevoegde autoriteit opgezet gecontroleerd kader dat aanbieders of toekomstige aanbieders van AI-systemen de mogelijkheid biedt een innovatief AI-systeem te ontwikkelen, trainen, valideren en testen, zo nodig onder reële omstandigheden, volgens een testomgevingsplan, voor een beperkte periode en onder begeleiding van een toezichthouder."
+  definition: een door een bevoegde autoriteit opgezet gecontroleerd kader dat aanbieders
+    of toekomstige aanbieders van AI-systemen de mogelijkheid biedt een innovatief
+    AI-systeem te ontwikkelen, trainen, valideren en testen, zo nodig onder reële
+    omstandigheden, volgens een testomgevingsplan, voor een beperkte periode en onder
+    begeleiding van een toezichthouder.
 - term: algoritme
-  definition: "Een set van regels en instructies die een computer geautomatiseerd volgt bij het maken van berekeningen om een probleem op te lossen of een vraag te beantwoorden."
+  definition: Een set van regels en instructies die een computer geautomatiseerd volgt
+    bij het maken van berekeningen om een probleem op te lossen of een vraag te beantwoorden.
 - term: auteursrecht
-  definition: "Het auteursrecht is het uitsluitend recht van den maker van een werk van letterkunde, wetenschap of kunst, of van diens rechtverkrijgenden, om dit openbaar te maken en te verveelvoudigen, behoudens de beperkingen, bij de wet gesteld."
+  definition: Het auteursrecht is het uitsluitend recht van den maker van een werk
+    van letterkunde, wetenschap of kunst, of van diens rechtverkrijgenden, om dit
+    openbaar te maken en te verveelvoudigen, behoudens de beperkingen, bij de wet
+    gesteld.
 - term: AVG
-  definition: "Algemene Verordening Gegevensbescherming"
+  definition: Algemene Verordening Gegevensbescherming
 - term: Awb
-  definition: "Algemene wet bestuursrecht"
+  definition: Algemene wet bestuursrecht
 - term: beoogd doel
-  definition: "Het gebruik waarvoor een AI-systeem door de aanbieder is bedoeld, met inbegrip van de specifieke context en voorwaarden van het gebruik, zoals gespecificeerd in de informatie die door de aanbieder in de gebruiksinstructies, reclame- of verkoopmaterialen en verklaringen, alsook in de technische documentatie is verstrekt."
+  definition: Het gebruik waarvoor een AI-systeem door de aanbieder is bedoeld, met
+    inbegrip van de specifieke context en voorwaarden van het gebruik, zoals gespecificeerd
+    in de informatie die door de aanbieder in de gebruiksinstructies, reclame- of
+    verkoopmaterialen en verklaringen, alsook in de technische documentatie is verstrekt
 - term: besluit (Awb)
-  definition: Een schriftelijke beslissing van een bestuursorgaan, inhoudende een publiekrechtelijke rechtshandeling.
+  definition: Een schriftelijke beslissing van een bestuursorgaan, inhoudende een
+    publiekrechtelijke rechtshandeling.
 - term: bijzondere categorieën persoonsgegevens
-  definition: "De categorieën persoonsgegevens als bedoeld in artikel 9, lid 1, van Verordening (EU) 2016/679, artikel 10 van Richtlijn (EU) 2016/680 en artikel 10, lid 1, van Verordening (EU) 2018/1725."
+  definition: de categorieën persoonsgegevens als bedoeld in artikel 9, lid 1, van
+    Verordening (EU) 2016/679, artikel 10 van Richtlijn (EU) 2016/680 en artikel 10,
+    lid 1, van Verordening (EU) 2018/1725
 - term: biometrie
-  definition: "1) Systemen voor biometrische identificatie op afstand (dit geldt niet voor AI-systemen die bedoeld zijn om te worden gebruikt voor biometrische verificatie met als enig doel te bevestigen dat een specifieke natuurlijke persoon de persoon is die hij of zij beweert te zijn)\n
-      2) AI-systemen die bedoeld zijn om te worden gebruikt voor biometrische categorisering op basis van gevoelige of beschermde eigenschappen of kenmerken, of op basis van wat uit die eigenschappen of kenmerken wordt afgeleid\n
-      3) AI-systemen die bedoeld zijn om te worden gebruikt voor emotieherkenning"
+  definition: "1) Systemen voor biometrische identificatie op afstand (dit geldt niet\
+    \ voor AI-systemen die bedoeld zijn om te worden gebruikt voor biometrische verificatie\
+    \ met als enig doel te bevestigen dat een specifieke natuurlijke persoon de persoon\
+    \ is die hij of zij beweert te zijn)\n 2) AI-systemen die bedoeld zijn om te worden\
+    \ gebruikt voor biometrische categorisering op basis van gevoelige of beschermde\
+    \ eigenschappen of kenmerken, of op basis van wat uit die eigenschappen of kenmerken\
+    \ wordt afgeleid\n 3) AI-systemen die bedoeld zijn om te worden gebruikt voor\
+    \ emotieherkenning"
 - term: biometrische gegevens
-  definition: "Persoonsgegevens die het resultaat zijn van een specifieke technische verwerking met betrekking tot de fysieke, fysiologische of gedragsgerelateerde kenmerken van een natuurlijk persoon, zoals gezichtsafbeeldingen of vingerafdrukgegevens."
+  definition: persoonsgegevens die het resultaat zijn van een specifieke technische
+    verwerking met betrekking tot de fysieke, fysiologische of gedragsgerelateerde
+    kenmerken van een natuurlijk persoon, zoals gezichtsafbeeldingen of vingerafdrukgegevens
 - term: biometrische identificatie
-  definition: "De geautomatiseerde herkenning van fysieke, fysiologische, gedragsgerelateerde of psychologische menselijke kenmerken om de identiteit van een natuurlijk persoon vast te stellen door biometrische gegevens van die persoon te vergelijken met in een databank opgeslagen biometrische gegevens van personen."
+  definition: de geautomatiseerde herkenning van fysieke, fysiologische, gedragsgerelateerde
+    of psychologische menselijke kenmerken om de identiteit van een natuurlijk persoon
+    vast te stellen door biometrische gegevens van die persoon te vergelijken met
+    in een databank opgeslagen biometrische gegevens van personen
 - term: biometrische verificatie
-  definition: "De geautomatiseerde één-op-éénverificatie, met inbegrip van de authenticatie, van de identiteit van natuurlijke personen door hun biometrische gegevens te vergelijken met eerder verstrekte biometrische gegevens."
+  definition: de geautomatiseerde één-op-éénverificatie, met inbegrip van de authenticatie,
+    van de identiteit van natuurlijke personen door hun biometrische gegevens te vergelijken
+    met eerder verstrekte biometrische gegevens
 - term: capaciteiten met een grote impact
-  definition: "Capaciteiten die overeenkomen met of groter zijn dan de capaciteiten die worden opgetekend bij de meest geavanceerde AI-modellen voor algemene doeleinden."
+  definition: capaciteiten die overeenkomen met of groter zijn dan de capaciteiten
+    die worden opgetekend bij de meest geavanceerde AI-modellen voor algemene doeleinden.
 - term: CE-markering
-  definition: "Een markering waarmee een aanbieder aangeeft dat een AI-systeem in overeenstemming is met de voorschriften van hoofdstuk III, afdeling 2, van de AI-Verordening en andere toepasselijke harmonisatiewetgeving van de Unie, die in het aanbrengen ervan voorzien."
+  definition: Een markering waarmee een aanbieder aangeeft dat een AI-systeem in overeenstemming
+    is met de voorschriften van hoofdstuk III, afdeling 2, en andere toepasselijke
+    harmonisatiewetgeving van de Unie, die in het aanbrengen ervan voorzien
 - term: conformiteitsbeoordeling
-  definition: "Het proces waarbij de naleving wordt aangetoond van de voorschriften van hoofdstuk III, afdeling 2 van de AI-Verordening in verband met een AI-systeem met een hoog risico."
+  definition: Het proces waarbij de naleving wordt aangetoond van de voorschriften
+    van hoofdstuk III, afdeling 2 van de AI-Verordening in verband met een AI-systeem
+    met een hoog risico
 - term: deepfake
-  definition: "Door AI gegenereerd of gemanipuleerd beeld-, audio- of videomateriaal dat een gelijkenis vertoont met bestaande personen, voorwerpen, plaatsen, entiteiten of gebeurtenissen, en door een persoon ten onrechte voor authentiek of waarheidsgetrouw zou worden aangezien."
+  definition: door AI gegenereerd of gemanipuleerd beeld-, audio- of videomateriaal
+    dat een gelijkenis vertoont met bestaande personen, voorwerpen, plaatsen, entiteiten
+    of gebeurtenissen, en door een persoon ten onrechte voor authentiek of waarheidsgetrouw
+    zou worden aangezien
 - term: direct onderscheid
-  definition: "Indien een persoon op een andere wijze wordt behandeld dan een ander in een vergelijkbare situatie wordt, is of zou worden behandeld, op grond van godsdienst, levensovertuiging, politieke gezindheid, ras, geslacht, nationaliteit, hetero- of homoseksuele gerichtheid of burgerlijke staat."
+  definition: Indien een persoon op een andere wijze wordt behandeld dan een ander
+    in een vergelijkbare situatie wordt, is of zou worden behandeld, op grond van
+    godsdienst, levensovertuiging, politieke gezindheid, ras, geslacht, nationaliteit,
+    hetero- of homoseksuele gerichtheid of burgerlijke staat;
 - term: directe discriminatie
-  definition: "De ongelijke behandeling van een persoon of groep personen ten opzichte van andere personen in een vergelijkbare situatie, op grond van een beschermd persoonskenmerk (discriminatiegrond)."
+  definition: De ongelijke behandeling van een persoon of groep personen ten opzichte
+    van andere personen in een vergelijkbare situatie, op grond van een beschermd
+    persoonskenmerk (discriminatiegrond).
 - term: discriminatiegrond
-  definition: "Beschermde persoonskenmerken op basis waarvan het maken van onderscheid tussen personen verboden is. Bijvoorbeeld: ras, nationaliteit, religie, geslacht, seksuele gerichtheid, handicap of chronische ziekte."
+  definition: 'Beschermde persoonskenmerken op basis waarvan het maken van onderscheid
+    tussen personen verboden is. Bijvoorbeeld: ras, nationaliteit, religie, geslacht,
+    seksuele gerichtheid, handicap of chronische ziekte.'
 - term: distributeur
-  definition: "Een andere natuurlijke persoon of rechtspersoon in de toeleveringsketen dan de aanbieder of de importeur, die een AI-systeem in de Unie op de markt aanbiedt."
+  definition: Een andere natuurlijke persoon of rechtspersoon in de toeleveringsketen
+    dan de aanbieder of de importeur, die een AI-systeem in de Unie op de markt aanbiedt
 - term: downstreamaanbieder
-  definition: "Een aanbieder van een AI-systeem, met inbegrip van een AI-systeem voor algemene doeleinden, waarin een AI-model is geïntegreerd, ongeacht of het model door hemzelf wordt verstrekt en verticaal geïntegreerd is of door een andere entiteit wordt aangeboden op basis van contractuele betrekkingen."
+  definition: Een aanbieder van een AI-systeem, met inbegrip van een AI-systeem voor
+    algemene doeleinden, waarin een AI-model is geïntegreerd, ongeacht of het model
+    door hemzelf wordt verstrekt en verticaal geïntegreerd is of door een andere entiteit
+    wordt aangeboden op basis van contractuele betrekkingen
 - term: etnisch profileren
-  definition: "Het gebruik door overheidsinstanties van selectiecriteria als ras, huidskleur, taal, religie, nationaliteit of nationale of etnische afkomst bij de uitoefening van toezichts-, handhavings- en opsporingsbevoegdheden, zonder dat daarvoor een object"
+  definition: Het gebruik door overheidsinstanties van selectiecriteria als ras, huidskleur,
+    taal, religie, nationaliteit of nationale of etnische afkomst bij de uitoefening
+    van toezichts-, handhavings- en opsporingsbevoegdheden, zonder dat daarvoor een
+    objectieve en redelijke rechtvaardiging bestaat
 - term: gemeenschappelijke specificatie
-  definition: "Een reeks technische specificaties zoals gedefinieerd in artikel 2, punt 4, van Verordening (EU) nr. 1025/2012, om te voldoen aan bepaalde voorschriften zoals vastgelegd in de AI-verordening."
+  definition: een reeks technische specificaties zoals gedefinieerd in artikel 2,
+    punt 4, van Verordening (EU) nr. 1025/2012, om te voldoen aan bepaalde voorschriften
+    zoals vastgelegd in deze verordening
 - term: gebruiksinstructies
-  definition: "De door de aanbieder verstrekte informatie om de gebruiksverantwoordelijke te informeren over met name het beoogde doel en juiste gebruik van een AI-systeem."
+  definition: de door de aanbieder verstrekte informatie om de gebruiksverantwoordelijke
+    te informeren over met name het beoogde doel en juiste gebruik van een AI-systeem
 - term: gebruiksverantwoordelijke
-  definition: "Een natuurlijke of rechtspersoon, overheidsinstantie, agentschap of ander orgaan die/dat een AI-systeem onder eigen verantwoordelijkheid gebruikt, tenzij het AI-systeem wordt gebruikt in het kader van een persoonlijke niet- beroepsactiviteit."
+  definition: Een natuurlijke of rechtspersoon, overheidsinstantie, agentschap of
+    ander orgaan die/dat een AI-systeem onder eigen verantwoordelijkheid gebruikt,
+    tenzij het AI-systeem wordt gebruikt in het kader van een persoonlijke niet- beroepsactiviteit.
 - term: geharmoniseerde norm
-  definition: "Een Europese norm die op verzoek van de Commissie is vastgesteld met het oog op de toepassing van harmonisatiewetgeving van de Unie. Een geharmoniseerde norm zoals gedefinieerd in artikel 2, lid 1,punt c), van Verordening (EU) nr. 1025/2012."
+  definition: Een Europese norm die op verzoek van de Commissie is vastgesteld met
+    het oog op de toepassing van harmonisatiewetgeving van de Unie
 - term: geïnformeerde toestemming
-  definition: "De vrijelijk gegeven, specifieke, ondubbelzinnige en vrijwillige uiting door een proefpersoon van zijn of haar bereidheid deel te nemen aan een bepaalde test onder reële omstandigheden, na geïnformeerd te zijn over alle aspecten van de test die van belang zijn voor zijn of haar beslissing om deel te nemen."
+  definition: de vrijelijk gegeven, specifieke, ondubbelzinnige en vrijwillige uiting
+    door een proefpersoon van zijn of haar bereidheid deel te nemen aan een bepaalde
+    test onder reële omstandigheden, na geïnformeerd te zijn over alle aspecten van
+    de test die van belang zijn voor zijn of haar beslissing om deel te nemen
 - term: gemachtigde
-  definition: "Een natuurlijke of rechtspersoon die zich bevindt of gevestigd is in de Unie die een schriftelijke machtiging heeft gekregen en aanvaard van een aanbieder van een AI-systeem of een AI-model voor algemene doeleinden om namens die aanbieder de verplichtingen en procedures van deze verordening respectievelijk na te komen en uit te voeren."
+  definition: een natuurlijke of rechtspersoon die zich bevindt of gevestigd is in
+    de Unie die een schriftelijke machtiging heeft gekregen en aanvaard van een aanbieder
+    van een AI-systeem of een AI-model voor algemene doeleinden om namens die aanbieder
+    de verplichtingen en procedures van deze verordening respectievelijk na te komen
+    en uit te voeren;
 - term: gemeenschappelijke specificatie
-  definition: "Een reeks technische specificaties zoals gedefinieerd in artikel 2, punt 4, van Verordening (EU) nr. 1025/2012, om te voldoen aan bepaalde voorschriften zoals vastgelegd in deze verordening."
+  definition: een reeks technische specificaties zoals gedefinieerd in artikel 2,
+    punt 4, van Verordening (EU) nr. 1025/2012, om te voldoen aan bepaalde voorschriften
+    zoals vastgelegd in deze verordening
 - term: gevoelige operationele gegevens
-  definition: "Operationele gegevens met betrekking tot activiteiten op het gebied van preventie, opsporing, onderzoek of vervolging van strafbare feiten waarvan de openbaarmaking de integriteit van strafprocedures in het gedrang zou kunnen brengen."
+  definition: operationele gegevens met betrekking tot activiteiten op het gebied
+    van preventie, opsporing, onderzoek of vervolging van strafbare feiten waarvan
+    de openbaarmaking de integriteit van strafprocedures in het gedrang zou kunnen
+    brengen
 - term: governance
-  definition: "Governance gaat over de inrichting van een organisatie en de bijbehorende processen, regels, gebruiken en verantwoordelijkheden."
+  definition: Governance gaat over de inrichting van een organisatie en de bijbehorende
+    processen, regels, gebruiken en verantwoordelijkheden.
 - term: importeur
-  definition: "Een natuurlijke of rechtspersoon die zich bevindt of gevestigd is in de Unie die een AI-systeem in de handel brengt dat de naam of merknaam van een in een derde land gevestigde natuurlijke of rechtspersoon draagt."
+  definition: Een natuurlijke of rechtspersoon die zich bevindt of gevestigd is in
+    de Unie die een AI-systeem in de handel brengt dat de naam of merknaam van een
+    in een derde land gevestigde natuurlijke of rechtspersoon draagt
 - term: in de handel brengen
-  definition: "Het voor het eerst in de Unie op de markt aanbieden van een AI-systeem of een AI-model voor algemene doeleinden."
+  definition: Het voor het eerst in de Unie op de markt aanbieden van een AI-systeem
+    of een AI-model voor algemene doeleinden
 - term: in gebruik stellen
-  definition: "De directe levering van een AI-systeem door de aanbieder aan de gebruiksverantwoordelijke voor het eerste gebruik of voor eigen gebruik in de Unie voor het beoogde doel."
+  definition: De directe levering van een AI-systeem door de aanbieder aan de gebruiksverantwoordelijke
+    voor het eerste gebruik of voor eigen gebruik in de Unie voor het beoogde doel
 - term: indirect onderscheid
-  definition: "Indien een ogenschijnlijk neutrale bepaling, maatstaf of handelwijze personen met een bepaalde godsdienst, levensovertuiging, politieke gezindheid, ras, geslacht, nationaliteit, hetero- of homoseksuele gerichtheid of burgerlijke staat in vergelijking met andere personen bijzonder treft."
+  definition: Indien een ogenschijnlijk neutrale bepaling, maatstaf of handelwijze
+    personen met een bepaalde godsdienst, levensovertuiging, politieke gezindheid,
+    ras, geslacht, nationaliteit, hetero- of homoseksuele gerichtheid of burgerlijke
+    staat in vergelijking met andere personen bijzonder treft.
 - term: indirecte discriminatie
-  definition: "Wanneer een ogenschijnlijk neutrale bepaling, maatstaf of handelwijze personen met een bepaald beschermd persoonskenmerk (discriminatiegrond) in vergelijking met andere personen in het bijzonder benadeelt, tenzij hiervoor een objectieve rechtvaardiging bestaat."
+  definition: Wanneer een ogenschijnlijk neutrale bepaling, maatstaf of handelwijze
+    personen met een bepaald beschermd persoonskenmerk (discriminatiegrond) in vergelijking
+    met andere personen in het bijzonder benadeelt, tenzij hiervoor een objectieve
+    rechtvaardiging bestaat.
 - term: inferentie
-  definition: Het vermogen om outputs te genereren zoals voorspellingen, inhoud, aanbevelingen of beslissingen die fysieke of virtuele omgevingen kunnen beïnvloeden.
+  definition: Het vermogen om outputs te genereren zoals voorspellingen, inhoud, aanbevelingen
+    of beslissingen die fysieke of virtuele omgevingen kunnen beïnvloeden.
 - term: inputdata
-  definition: "Data die in een AI-systeem worden ingevoerd of direct door een AI-systeem worden verworven en op basis waarvan het systeem een output genereert."
+  definition: data die in een AI-systeem worden ingevoerd of direct door een AI-systeem
+    worden verworven en op basis waarvan het systeem een output genereert
 - term: kritieke infrastructuur
-  definition: "Kritieke infrastructuur zoals gedefinieerd in artikel 2, punt 4, van Richtlijn (EU) 2022/2557. Hieronder vallen AI-systemen die bedoeld zijn om te worden gebruikt als veiligheidscomponent bij het beheer of de exploitatie van kritieke digitale infrastructuur, wegverkeer of bij de levering van water, gas, verwarming en elektriciteit."
+  definition: kritieke infrastructuur zoals gedefinieerd in artikel 2, punt 4, van
+    Richtlijn (EU) 2022/2557
 - term: legaliteitsbeginsel
-  definition: "Het legaliteitsbeginsel houdt in dat alle overheidsoptreden moet berusten op een overeenstemmen met - kenbare en voldoende specifieke - algemene regels."
+  definition: Het legaliteitsbeginsel houdt in dat alle overheidsoptreden moet berusten
+    op een overeenstemmen met - kenbare en voldoende specifieke - algemene regels.
 - term: markttoezichtautoriteit
-  definition: "De nationale autoriteit die de activiteiten verricht en maatregelen neemt als bedoeld in Verordening (EU) 2019/1020."
+  definition: de nationale autoriteit die de activiteiten verricht en maatregelen
+    neemt als bedoeld in Verordening (EU) 2019/1020
 - term: migratie-, asiel- en grenstoezichtsbeheer
-  definition: "1) AI-systemen die bedoeld zijn om door of namens bevoegde overheidsinstanties of door instellingen, organen of instanties van de Unie te worden gebruikt als leugendetector of soortgelijke hulpmiddelen \n
-       2) AI-systemen die bedoeld zijn om door of namens bevoegde overheidsinstanties of door instellingen, organen of instanties van de Unie te worden gebruikt om risico’s te beoordelen, waaronder een veiligheidsrisico, een risico op illegale migratie of een gezondheidsrisico, uitgaat van een natuurlijke persoon die voornemens is het grondgebied van een lidstaat te betreden of dat heeft gedaan \n
-       3) AI-systemen die bedoeld zijn om door of namens bevoegde overheidsinstanties of door instellingen, organen of instanties van de Unie te worden gebruikt om bevoegde overheidsinstanties bij te staan bij de behandeling van aanvragen voor asiel, visa of verblijfsvergunningen en bij de behandeling van aanverwante klachten in verband met het al dan niet in aanmerking komen van de natuurlijke personen die een aanvraag voor een status indienen, met inbegrip van hieraan gerelateerde beoordelingen van de betrouwbaarheid van bewijsmateriaal \n
-       4) AI-systemen die bedoeld zijn om door of namens bevoegde overheidsinstanties, of door instellingen, organen of instanties van de Unie, te worden gebruikt in het kader van migratie-, asiel- of grenstoezichtsbeheer, met het oog op het opsporen, herkennen of identificeren van natuurlijke personen, met uitzondering van de verificatie van reisdocumenten."
+  definition: "1) AI-systemen die bedoeld zijn om door of namens bevoegde overheidsinstanties\
+    \ of door instellingen, organen of instanties van de Unie te worden gebruikt als\
+    \ leugendetector of soortgelijke hulpmiddelen \n 2) AI-systemen die bedoeld zijn\
+    \ om door of namens bevoegde overheidsinstanties of door instellingen, organen\
+    \ of instanties van de Unie te worden gebruikt om risico’s te beoordelen, waaronder\
+    \ een veiligheidsrisico, een risico op illegale migratie of een gezondheidsrisico,\
+    \ uitgaat van een natuurlijke persoon die voornemens is het grondgebied van een\
+    \ lidstaat te betreden of dat heeft gedaan \n 3) AI-systemen die bedoeld zijn\
+    \ om door of namens bevoegde overheidsinstanties of door instellingen, organen\
+    \ of instanties van de Unie te worden gebruikt om bevoegde overheidsinstanties\
+    \ bij te staan bij de behandeling van aanvragen voor asiel, visa of verblijfsvergunningen\
+    \ en bij de behandeling van aanverwante klachten in verband met het al dan niet\
+    \ in aanmerking komen van de natuurlijke personen die een aanvraag voor een status\
+    \ indienen, met inbegrip van hieraan gerelateerde beoordelingen van de betrouwbaarheid\
+    \ van bewijsmateriaal \n 4) AI-systemen die bedoeld zijn om door of namens bevoegde\
+    \ overheidsinstanties, of door instellingen, organen of instanties van de Unie,\
+    \ te worden gebruikt in het kader van migratie-, asiel- of grenstoezichtsbeheer,\
+    \ met het oog op het opsporen, herkennen of identificeren van natuurlijke personen,\
+    \ met uitzondering van de verificatie van reisdocumenten."
 - term: nationale bevoegde autoriteit
-  definition: "Een aanmeldende autoriteit of een markttoezichtautoriteit; wat betreft AI-systemen die door instellingen, organen en instanties van de EU in gebruik worden gesteld of worden gebruikt, worden verwijzingen naar nationale bevoegde autoriteiten of markttoezichtautoriteiten in deze verordening begrepen als verwijzingen naar de Europese Toezichthouder voor gegevensbescherming."
+  definition: een aanmeldende autoriteit of een de markttoezichtautoriteit; wat betreft
+    AI-systemen die door instellingen, organen en instanties van de EU in gebruik
+    worden gesteld of worden gebruikt, worden verwijzingen naar nationale bevoegde
+    autoriteiten of markttoezichtautoriteiten in deze verordening begrepen als verwijzingen
+    naar de Europese Toezichthouder voor gegevensbescherming
 - term: norm
-  definition: "Een norm is een vrijwillige afspraak tussen partijen over een product, dienst of proces. Normen zijn geen wetten, maar 'best practices'. Iedereen kan - op vrijwillige basis - hier zijn voordeel mee doen. In zakelijke overeenkomsten hebben normen een belangrijke functie. Ze bieden marktpartijen duidelijkheid over en vertrouwen in producten, diensten of organisaties en dagen de maatschappij uit te innoveren. NEN-normen worden ontwikkeld door inhoudsexperts en specialisten op het gebied van normontwikkeling."
+  definition: een norm is een vrijwillige afspraak tussen partijen over een product,
+    dienst of proces. Normen zijn geen wetten, maar ’best practices’. Iedereen kan
+    - op vrijwillige basis - hier zijn voordeel mee doen. In zakelijke overeenkomsten
+    hebben normen een belangrijke functie. Ze bieden marktpartijen duidelijkheid over
+    en vertrouwen in producten, diensten of organisaties en dagen de maatschappij
+    uit te innoveren. NEN-normen worden ontwikkeld door inhoudsexperts en specialisten
+    op het gebied van normontwikkeling.
 - term: normalisatie
-  definition: "Normalisatie is het proces om te komen tot een norm. Dit proces is open, transparant en gericht op consensus en vindt plaats in normcommissies die bestaan uit vertegenwoordigers van alle betrokken partijen. Dit gebeurt niet alleen op nationaal niveau, maar ook in Europees en mondiaal verband."
+  definition: Normalisatie is het proces om te komen tot een norm. Dit proces is open,
+    transparant en gericht op consensus en vindt plaats in normcommissies die bestaan
+    uit vertegenwoordigers van alle betrokken partijen. Dit gebeurt niet alleen op
+    nationaal niveau, maar ook in Europees en mondiaal verband.
 - term: onderwijs en beroepsopleiding
-  definition: "1) AI-systemen die bedoeld zijn om te worden gebruikt voor het bepalen van toegang of toelating tot of het toewijzen van natuurlijke personen aan instellingen voor onderwijs en beroepsonderwijs op alle niveaus\n
-    2) AI-systemen die bedoeld zijn om te worden gebruikt voor het evalueren van leerresultaten, ook wanneer die resultaten worden gebruikt voor het sturen van het leerproces van natuurlijke personen in instellingen voor onderwijs en beroepsonderwijs op alle niveaus\n
-    3) AI-systemen die bedoeld zijn om te worden gebruikt voor het beoordelen van het passende onderwijsniveau dat een persoon zal ontvangen of waartoe hij toegang zal hebben, in het kader van of binnen instellingen voor onderwijs en beroepsonderwijs op alle niveaus\n
-    4) AI-systemen die bedoeld zijn om te worden gebruikt voor het monitoren en detecteren van ongeoorloofd gedrag van studenten tijdens toetsen in de context van of binnen instellingen voor onderwijs en beroepsonderwijs op alle niveaus."
+  definition: "1) AI-systemen die bedoeld zijn om te worden gebruikt voor het bepalen\
+    \ van toegang of toelating tot of het toewijzen van natuurlijke personen aan instellingen\
+    \ voor onderwijs en beroepsonderwijs op alle niveaus\n 2) AI-systemen die bedoeld\
+    \ zijn om te worden gebruikt voor het evalueren van leerresultaten, ook wanneer\
+    \ die resultaten worden gebruikt voor het sturen van het leerproces van natuurlijke\
+    \ personen in instellingen voor onderwijs en beroepsonderwijs op alle niveaus\n\
+    \ 3) AI-systemen die bedoeld zijn om te worden gebruikt voor het beoordelen van\
+    \ het passende onderwijsniveau dat een persoon zal ontvangen of waartoe hij toegang\
+    \ zal hebben, in het kader van of binnen instellingen voor onderwijs en beroepsonderwijs\
+    \ op alle niveaus\n 4) AI-systemen die bedoeld zijn om te worden gebruikt voor\
+    \ het monitoren en detecteren van ongeoorloofd gedrag van studenten tijdens toetsen\
+    \ in de context van of binnen instellingen voor onderwijs en beroepsonderwijs\
+    \ op alle niveaus."
 - term: objectieve rechtvaardiging
-  definition: "Van een objectieve rechtvaardiging voor onderscheid is sprake wanneer onderscheid een legitiem doel nastreeft en er een redelijke relatie van evenredigheid bestaat tussen het gemaakte onderscheid en het nagestreefde doel."
+  definition: Van een objectieve rechtvaardiging voor onderscheid is sprake wanneer
+    onderscheid een legitiem doel nastreeft en er een redelijke relatie van evenredigheid
+    bestaat tussen het gemaakte onderscheid en het nagestreefde doel.
 - term: op de markt aanbieden
-  definition: "Het in het kader van een handelsactiviteit, al dan niet tegen betaling, verstrekken van een AI-systeem of een AI-model voor algemene doeleinden met het oog op distributie of gebruik op de markt van de Unie."
+  definition: Het in het kader van een handelsactiviteit, al dan niet tegen betaling,
+    verstrekken van een AI-systeem of een AI-model voor algemene doeleinden met het
+    oog op distributie of gebruik op de markt van de Unie
 - term: operator
-  definition: "Een aanbieder, productfabrikant, gebruiksverantwoordelijke, gemachtigde, importeur of distributeur."
+  definition: een aanbieder, productfabrikant, gebruiksverantwoordelijke, gemachtigde,
+    importeur of distributeur
 - term: prestaties van een AI-systeem
-  definition: "Het vermogen van een AI-systeem om het beoogde doel te verwezenlijken."
+  definition: het vermogen van een AI-systeem om het beoogde doel te verwezenlijken
 - term: plan voor testen onder reële omstandigheden
-  definition: "Een document waarin de doelstellingen, methode, geografische reikwijdte, betrokken personen, duur, monitoring, organisatie en wijze van uitvoering van een test onder reële omstandigheden worden omschreven."
+  definition: een document waarin de doelstellingen, methode, geografische reikwijdte,
+    betrokken personen, duur, monitoring, organisatie en wijze van uitvoering van
+    een test onder reële omstandigheden worden omschreven
 - term: proceseigenaar
-  definition: "De proceseigenaar is verantwoordelijk voor de kwaliteit van het proces en de vastlegging daarvan in een processchema."
+  definition: De proceseigenaar is verantwoordelijk voor de kwaliteit van het proces
+    en de vastlegging daarvan in een processchema
 - term: proefpersoon
-  definition: "In het kader van tests onder reële omstandigheden: een natuurlijk persoon die deelneemt aan een test onder reële omstandigheden."
+  definition: 'In het kader van tests onder reële omstandigheden: een natuurlijk persoon
+    die deelneemt aan een test onder reële omstandigheden'
 - term: profilering
-  definition: "Elke vorm van geautomatiseerde verwerking van persoonsgegevens waarbij aan de hand van persoonsgegevens bepaalde persoonlijke aspecten van een natuurlijke persoon worden geëvalueerd, met name met de bedoeling zijn beroepsprestaties, economische situatie, gezondheid, persoonlijke voorkeuren, interesses, betrouwbaarheid, gedrag, locatie of verplaatsingen te analyseren of te voorspellen. Het gaat om een verwerking door een individu met gebruikmaking van diens persoonsgegevens in te delen in een categorie (profiel), vaak in verband met aan dat profiel toegedichte risico's."
+  definition: Elke vorm van geautomatiseerde verwerking van persoonsgegevens waarbij
+    aan de hand van persoonsgegevens bepaalde persoonlijke aspecten van een natuurlijke
+    persoon worden geëvalueerd, met name met de bedoeling zijn beroepsprestaties,
+    economische situatie, gezondheid, persoonlijke voorkeuren, interesses, betrouwbaarheid,
+    gedrag, locatie of verplaatsingen te analyseren of te voorspellen. Het gaat om
+    een verwerking door een individu met gebruikmaking van diens persoonsgegevens
+    in te delen in een categorie (profiel), vaak in verband met aan dat profiel toegedichte
+    risico's.
 - term: publieke inkoop
-  definition: "De verwerving van werken, leveringen of diensten door een overheid of publieke organisatie, van de markt of een andere externe instantie, terwijl zij tegelijkertijd publieke waarde creëren en waarborgen vanuit het perspectief van de eigen organisatie."
+  definition: De verwerving van werken, leveringen of diensten door een overheid of
+    publieke organisatie, van de markt of een andere externe instantie, terwijl zij
+    tegelijkertijd publieke waarde creëren en waarborgen vanuit het perspectief van
+    de eigen organisatie.
 - term: rechtsbedeling en democratische processen
-  definition: "1) AI-systemen die bedoeld zijn om door of namens een gerechtelijke instantie te worden gebruikt om een gerechtelijke instantie te ondersteunen bij het onderzoeken en uitleggen van feiten of de wet en bij de toepassing van het recht op een concrete reeks feiten of om te worden gebruikt op soortgelijke wijze in het kader van alternatieve geschillenbeslechting \n
-      2) AI-systemen die bedoeld zijn om te worden gebruikt voor het beïnvloeden van de uitslag van een verkiezing of referendum of van het stemgedrag van natuurlijke personen bij de uitoefening van hun stemrecht bij verkiezingen of referenda. Dit geldt niet voor AI-systemen aan de output waarvan natuurlijke personen niet rechtstreeks worden blootgesteld, zoals instrumenten die worden gebruikt om politieke campagnes te organiseren, te optimaliseren of te structureren vanuit administratief of logistiek oogpunt."
+  definition: "1) AI-systemen die bedoeld zijn om door of namens een gerechtelijke\
+    \ instantie te worden gebruikt om een gerechtelijke instantie te ondersteunen\
+    \ bij het onderzoeken en uitleggen van feiten of de wet en bij de toepassing van\
+    \ het recht op een concrete reeks feiten of om te worden gebruikt op soortgelijke\
+    \ wijze in het kader van alternatieve geschillenbeslechting \n 2) AI-systemen\
+    \ die bedoeld zijn om te worden gebruikt voor het beïnvloeden van de uitslag van\
+    \ een verkiezing of referendum of van het stemgedrag van natuurlijke personen\
+    \ bij de uitoefening van hun stemrecht bij verkiezingen of referenda. Dit geldt\
+    \ niet voor AI-systemen aan de output waarvan natuurlijke personen niet rechtstreeks\
+    \ worden blootgesteld, zoals instrumenten die worden gebruikt om politieke campagnes\
+    \ te organiseren, te optimaliseren of te structureren vanuit administratief of\
+    \ logistiek oogpunt."
 - term: rechtshandhaving
-  definition: "1) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties, of door instellingen, organen of instanties van de Unie ter ondersteuning van rechtshandhavingsinstanties of namens hen, te worden gebruikt om het risico te beoordelen dat een natuurlijke persoon het slachtoffer wordt van strafbare feiten\n
-       2) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties of door instellingen, organen of instanties van de Unie ter ondersteuning van rechtshandhavingsinstanties te worden gebruikt als leugendetector of soortgelijke instrumenten \n
-       3) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties of door instellingen, organen of instanties van de Unie ter ondersteuning van rechtshandhavingsinstanties te worden gebruikt om de betrouwbaarheid van bewijsmateriaal tijdens het onderzoek naar of de vervolging van strafbare feiten te beoordelen
-       4) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties of door instellingen, organen of instanties van de Unie ter ondersteuning van rechtshandhavingsinstanties te worden gebruikt om te beoordelen hoe groot het risico is dat een natuurlijke persoon (opnieuw) een strafbaar feit zal plegen, niet uitsluitend op basis van profilering van natuurlijke personen, of om persoonlijkheidskenmerken en eigenschappen of eerder crimineel gedrag van natuurlijke personen of groepen te beoordelen \n
-       5) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties of door instellingen, organen en instanties van de Unie ter ondersteuning van rechtshandhavingsinstanties te worden gebruikt om natuurlijke personen te profileren tijdens het opsporen, onderzoeken of vervolgen van strafbare feiten."
+  definition: "1) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties,\
+    \ of door instellingen, organen of instanties van de Unie ter ondersteuning van\
+    \ rechtshandhavingsinstanties of namens hen, te worden gebruikt om het risico\
+    \ te beoordelen dat een natuurlijke persoon het slachtoffer wordt van strafbare\
+    \ feiten\n 2) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties\
+    \ of door instellingen, organen of instanties van de Unie ter ondersteuning van\
+    \ rechtshandhavingsinstanties te worden gebruikt als leugendetector of soortgelijke\
+    \ instrumenten \n 3) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties\
+    \ of door instellingen, organen of instanties van de Unie ter ondersteuning van\
+    \ rechtshandhavingsinstanties te worden gebruikt om de betrouwbaarheid van bewijsmateriaal\
+    \ tijdens het onderzoek naar of de vervolging van strafbare feiten te beoordelen\
+    \ 4) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties\
+    \ of door instellingen, organen of instanties van de Unie ter ondersteuning van\
+    \ rechtshandhavingsinstanties te worden gebruikt om te beoordelen hoe groot het\
+    \ risico is dat een natuurlijke persoon (opnieuw) een strafbaar feit zal plegen,\
+    \ niet uitsluitend op basis van profilering van natuurlijke personen, of om persoonlijkheidskenmerken\
+    \ en eigenschappen of eerder crimineel gedrag van natuurlijke personen of groepen\
+    \ te beoordelen \n 5) AI-systemen die bedoeld zijn om door of namens rechtshandhavingsinstanties\
+    \ of door instellingen, organen en instanties van de Unie ter ondersteuning van\
+    \ rechtshandhavingsinstanties te worden gebruikt om natuurlijke personen te profileren\
+    \ tijdens het opsporen, onderzoeken of vervolgen van strafbare feiten."
 - term: rechtsgevolg
-  definition: "Een verandering in het geheel van de rechten, aanspraken, bevoegdheden en verplichtingen van één of meer natuurlijke personen of rechtspersonen."
+  definition: Een verandering in het geheel van de rechten, aanspraken, bevoegdheden
+    en verplichtingen van één of meer natuurlijke personen of rechtspersonen.
 - term: redelijkerwijs te voorzien misbruik
-  definition: "Het gebruik van een AI-systeem op een wijze die niet in overeenstemming is met het beoogde doel, maar die kan voortvloeien uit redelijkerwijs te voorzien menselijk gedrag of redelijkerwijs te voorziene interactie met andere systemen, waaronder andere AI-systemen."
+  definition: Het gebruik van een AI-systeem op een wijze die niet in overeenstemming
+    is met het beoogde doel, maar die kan voortvloeien uit redelijkerwijs te voorzien
+    menselijk gedrag of redelijkerwijs te voorziene interactie met andere systemen,
+    waaronder andere AI-systemen
 - term: risico
-  definition: "De combinatie van de kans op schade en de ernst van die schade."
+  definition: De combinatie van de kans op schade en de ernst van die schade.
 - term: substantiële wijziging
-  definition: "Een verandering van een AI-systeem nadat dit in de handel is gebracht of in gebruik is gesteld, die door de aanbieder niet is voorzien of gepland in de initiële conformiteitsbeoordeling en als gevolg waarvan de overeenstemming van het AI-systeem met de voorschriften van hoofdstuk III, afdeling 2, AI-Verordening wordt beïnvloed, of die leidt tot een wijziging van het beoogde doel waarvoor het AI-systeem is beoordeeld."
+  definition: Een verandering van een AI-systeem nadat dit in de handel is gebracht
+    of in gebruik is gesteld, die door de aanbieder niet is voorzien of gepland in
+    de initiële conformiteitsbeoordeling en als gevolg waarvan de overeenstemming
+    van het AI-systeem met de voorschriften van hoofdstuk III, afdeling 2, wordt beïnvloed,
+    of die leidt tot een wijziging van het beoogde doel waarvoor het AI-systeem is
+    beoordeeld
 - term: systeem voor monitoring na het in de handel brengen
-  definition: "Alle door aanbieders van AI-systemen verrichte activiteiten voor het verzamelen en evalueren van ervaringen met door hen in de handel gebrachte of in gebruik gestelde AI-systemen, teneinde te kunnen vaststellen of er onmiddellijk corrigerende dan wel preventieve maatregelen nodig zijn."
+  definition: alle door aanbieders van AI-systemen verrichte activiteiten voor het
+    verzamelen en evalueren van ervaringen met door hen in de handel gebrachte of
+    in gebruik gestelde AI-systemen, teneinde te kunnen vaststellen of er onmiddellijk
+    corrigerende dan wel preventieve maatregelen nodig zijn
 - term: systeem voor het herkennen van emoties
-  definition: "Een AI-systeem dat is bedoeld voor het vaststellen of afleiden van de emoties of intenties van natuurlijke personen op basis van hun biometrische gegevens."
+  definition: een AI-systeem dat is bedoeld voor het vaststellen of afleiden van de
+    emoties of intenties van natuurlijke personen op basis van hun biometrische gegevens
 - term: systeem voor biometrische categorisering
-  definition: "Een AI-systeem dat is bedoeld voor het indelen van natuurlijke personen in specifieke categorieën op basis van hun biometrische gegevens, tenzij dit een aanvulling vormt op een andere commerciële dienst en om objectieve technische redenen strikt noodzakelijk is."
+  definition: een AI-systeem dat is bedoeld voor het indelen van natuurlijke personen
+    in specifieke categorieën op basis van hun biometrische gegevens, tenzij dit een
+    aanvulling vormt op een andere commerciële dienst en om objectieve technische
+    redenen strikt noodzakelijk is
 - term: systeem voor biometrische identificatie op afstand
-  definition: "Een AI-systeem dat is bedoeld voor het identificeren van natuurlijke personen, zonder dat zij daar actief bij betrokken zijn en doorgaans van een afstand, door middel van vergelijking van de biometrische gegevens van een persoon met de biometrische gegevens die zijn opgenomen in een referentiedatabank."
+  definition: een AI-systeem dat is bedoeld voor het identificeren van natuurlijke
+    personen, zonder dat zij daar actief bij betrokken zijn en doorgaans van een afstand,
+    door middel van vergelijking van de biometrische gegevens van een persoon met
+    de biometrische gegevens die zijn opgenomen in een referentiedatabank
 - term: systeem voor biometrische identificatie op afstand in real time
-  definition: "Een systeem voor biometrische identificatie op afstand, waarbij het vastleggen van biometrische gegevens, de vergelijking en de identificatie zonder significante vertraging plaatsvinden, zowel wanneer de identificatie niet enkel onmiddellijk plaatsvindt, maar ook wanneer de identificatie met beperkte korte vertragingen plaatsvindt, om omzeiling te voorkomen."
+  definition: een systeem voor biometrische identificatie op afstand, waarbij het
+    vastleggen van biometrische gegevens, de vergelijking en de identificatie zonder
+    significante vertraging plaatsvinden, zowel wanneer de identificatie niet enkel
+    onmiddellijk plaatsvindt, maar ook wanneer de identificatie met beperkte korte
+    vertragingen plaatsvindt, om omzeiling te voorkomen
 - term: systeem voor biometrische identificatie op afstand achteraf
-  definition: "Een ander biometrisch systeem voor de identificatie op afstand dan een systeem voor biometrische identificatie op afstand in real time."
+  definition: een ander biometrisch systeem voor de identificatie op afstand dan een
+    systeem voor biometrische identificatie op afstand in real time
 - term: systeemrisico
-  definition: "Een risico dat specifiek is voor de capaciteiten met een grote impact van AI-modellen voor algemene doeleinden, die aanzienlijke gevolgen hebben voor de markt van de Unie vanwege hun bereik, of vanwege feitelijke of redelijkerwijs te voorziene negatieve gevolgen voor de gezondheid, de veiligheid, de openbare veiligheid, de grondrechten of de samenleving als geheel, en dat op grote schaal in de hele waardeketen kan worden verspreid."
-- term: toegang tot en gebruik van essentiele particuliere en publieke diensten en uitkeringen
-  definition: "1) AI-systemen die bedoeld zijn om door of namens overheidsinstanties te worden gebruikt om te beoordelen of natuurlijke personen in aanmerking komen voor essentiële overheidsuitkeringen en -diensten, waaronder gezondheidsdiensten, of om dergelijke uitkeringen en diensten te verlenen, te beperken, in te trekken of terug te vorderen\n
-       2) AI-systemen die bedoeld zijn om te worden gebruikt voor het beoordelen van de kredietwaardigheid van natuurlijke personen of voor het vaststellen van hun kredietscore, met uitzondering van AI-systemen die gebruikt worden om financiële fraude op te sporen\n
-       3) AI-systemen die bedoeld zijn om te worden gebruikt voor risicobeoordeling en prijsstelling met betrekking tot natuurlijke personen in het geval van levens- en ziektekostenverzekeringen\n
-       4) AI-systemen die bedoeld zijn om noodoproepen van natuurlijke personen te evalueren en te classificeren of om te worden gebruikt voor het inzetten of het bepalen van prioriteiten voor de inzet van hulpdiensten, onder meer van politie, brandweer en ambulance, alsook van systemen voor de triage van patiënten die dringend medische zorg behoeven."
+  definition: een risico dat specifiek is voor de capaciteiten met een grote impact
+    van AI-modellen voor algemene doeleinden, die aanzienlijke gevolgen hebben voor
+    de markt van de Unie vanwege hun bereik, of vanwege feitelijke of redelijkerwijs
+    te voorziene negatieve gevolgen voor de gezondheid, de veiligheid, de openbare
+    veiligheid, de grondrechten of de samenleving als geheel, en dat op grote schaal
+    in de hele waardeketen kan worden verspreid
+- term: toegang tot en gebruik van essentiele particuliere en publieke diensten en
+    uitkeringen
+  definition: "1) AI-systemen die bedoeld zijn om door of namens overheidsinstanties\
+    \ te worden gebruikt om te beoordelen of natuurlijke personen in aanmerking komen\
+    \ voor essentiële overheidsuitkeringen en -diensten, waaronder gezondheidsdiensten,\
+    \ of om dergelijke uitkeringen en diensten te verlenen, te beperken, in te trekken\
+    \ of terug te vorderen\n 2) AI-systemen die bedoeld zijn om te worden gebruikt\
+    \ voor het beoordelen van de kredietwaardigheid van natuurlijke personen of voor\
+    \ het vaststellen van hun kredietscore, met uitzondering van AI-systemen die gebruikt\
+    \ worden om financiële fraude op te sporen\n 3) AI-systemen die bedoeld zijn om\
+    \ te worden gebruikt voor risicobeoordeling en prijsstelling met betrekking tot\
+    \ natuurlijke personen in het geval van levens- en ziektekostenverzekeringen\n\
+    \ 4) AI-systemen die bedoeld zijn om noodoproepen van natuurlijke personen te\
+    \ evalueren en te classificeren of om te worden gebruikt voor het inzetten of\
+    \ het bepalen van prioriteiten voor de inzet van hulpdiensten, onder meer van\
+    \ politie, brandweer en ambulance, alsook van systemen voor de triage van patiënten\
+    \ die dringend medische zorg behoeven."
 - term: terugroepen van een AI-systeem
-  definition: "Een maatregel gericht op het retourneren aan de aanbieder, het buiten gebruik stellen of het onbruikbaar maken van een AI-systeem dat aan gebruiksverantwoordelijken ter beschikking is gesteld."
+  definition: een maatregel gericht op het retourneren aan de aanbieder, het buiten
+    gebruik stellen of het onbruikbaar maken van een AI-systeem dat aan gebruiksverantwoordelijken
+    ter beschikking is gesteld
 - term: testdata
-  definition: "Data die worden gebruikt voor het verrichten van een onafhankelijke evaluatie van het AI-systeem om de verwachte prestaties van dat systeem te bevestigen voordat het in de handel wordt gebracht of in gebruik wordt gesteld."
+  definition: data die worden gebruikt voor het verrichten van een onafhankelijke
+    evaluatie van het AI-systeem om de verwachte prestaties van dat systeem te bevestigen
+    voordat het in de handel wordt gebracht of in gebruik wordt gesteld
 - term: testomgevingsplan
-  definition: "Tussen de deelnemende aanbieder en de bevoegde autoriteit overeengekomen document waarin de doelstellingen, de voorwaarden, het tijdschema, de methode en de vereisten voor de in de testomgeving uitgevoerde activiteiten worden beschreven."
+  definition: tussen de deelnemende aanbieder en de bevoegde autoriteit overeengekomen
+    document waarin de doelstellingen, de voorwaarden, het tijdschema, de methode
+    en de vereisten voor de in de testomgeving uitgevoerde activiteiten worden beschreven
 - term: testen onder reële omstandigheden
-  definition: "Het tijdelijk testen van een AI-systeem voor zijn beoogde doel onder reële omstandigheden buiten een laboratorium of anderszins gesimuleerde omgeving teneinde betrouwbare en robuuste gegevens te verkrijgen, en te beoordelen en te verifiëren of het AI-systeem overeenstemt met de voorschriften van de AI-verordening en het wordt niet aangemerkt als het in de handel brengen of in gebruik stellen van het AI-systeem in de zin van de AI-verordening, mits aan alle in artikel 57 of 60 vastgestelde voorwaarden is voldaan."
+  definition: het tijdelijk testen van een AI-systeem voor zijn beoogde doel onder
+    reële omstandigheden buiten een laboratorium of anderszins gesimuleerde omgeving
+    teneinde betrouwbare en robuuste gegevens te verkrijgen, en te beoordelen en te
+    verifiëren of het AI-systeem overeenstemt met de voorschriften van de AI-verordening
+    en het wordt niet aangemerkt als het in de handel brengen of in gebruik stellen
+    van het AI-systeem in de zin van de AI-verordening, mits aan alle in artikel 57
+    of 60 vastgestelde voorwaarden is voldaan
 - term: toestemming met kennis van zaken
-  definition: "De vrijelijk gegeven, specifieke, ondubbelzinnige en vrijwillige uiting door een proefpersoon van zijn of haar bereidheid deel te nemen aan een bepaalde test onder reële omstandigheden, na geïnformeerd te zijn over alle aspecten van de test die van belang zijn voor zijn of haar beslissing deel te nemen."
+  definition: de vrijelijk gegeven, specifieke, ondubbelzinnige en vrijwillige uiting
+    door een proefpersoon van zijn of haar bereidheid deel te nemen aan een bepaalde
+    test onder reële omstandigheden, na geïnformeerd te zijn over alle aspecten van
+    de test die van belang zijn voor zijn of haar beslissing deel te nemen
 - term: trainingsdata
-  definition: "Data die worden gebruikt voor het trainen van een AI-systeem door de leerbare parameters hiervan aan te passen."
+  definition: data die worden gebruikt voor het trainen van een AI-systeem door de
+    leerbare parameters hiervan aan te passen
 - term: uit de handel nemen van een AI-systeem
-  definition: "Een maatregel waarmee wordt beoogd te voorkomen dat een AI-systeem dat zich in de toeleveringsketen bevindt, op de markt wordt aangeboden."
+  definition: een maatregel waarmee wordt beoogd te voorkomen dat een AI-systeem dat
+    zich in de toeleveringsketen bevindt, op de markt wordt aangeboden
 - term: validatiedata
-  definition: "Data die worden gebruikt voor het verrichten van een evaluatie van het getrainde AI-systeem en voor het afstemmen van onder andere de niet-leerbare parameters en het leerproces ervan, om underfitting of overfitting te voorkomen."
+  definition: data die worden gebruikt voor het verrichten van een evaluatie van het
+    getrainde AI-systeem en voor het afstemmen van onder andere de niet-leerbare parameters
+    en het leerproces ervan, om underfitting of overfitting te voorkomen
 - term: validatiedataset
-  definition: "Een afzonderlijke dataset of deel van de trainingsdataset, als vaste of variabele opdeling."
+  definition: een afzonderlijke dataset of deel van de trainingsdataset, als vaste
+    of variabele opdeling.
 - term: veiligheidscomponent
-  definition: "Een component van een product of systeem die een veiligheidsfunctie voor dat product of systeem vervult of waarvan het falen of gebrekkig functioneren de gezondheid en veiligheid van personen of eigendom in gevaar brengt."
+  definition: Een component van een product of systeem die een veiligheidsfunctie
+    voor dat product of systeem vervult of waarvan het falen of gebrekkig functioneren
+    de gezondheid en veiligheid van personen of eigendom in gevaar brengt
 - term: verwerker
-  definition: "Een natuurlijke of rechtspersoon, een overheidsinstantie, een dienst of een ander orgaan die/dat ten behoeve van de verwerkingsverantwoordelijke persoonsgegevens verwerkt."
+  definition: Een .. rechtspersoon, een overheidsinstantie, een dienst of een ander
+    orgaan die/dat ten behoeve van de verwerkingsverantwoordelijke persoonsgegevens
+    verwerkt.
 - term: verwerkersverantwoordelijke
-  definition: "Een rechtspersoon of overheidsinstantie die, alleen of samen met anderen, het doel van en de middelen voor de verwerking van persoonsgegevens vaststelt."
+  definition: Een rechtspersoon of overheidsinstantie die, alleen of samen met anderen,
+    het doel van en de middelen voor de verwerking van persoonsgegevens vaststelt
 - term: werkgelegenheid, personeelsbeheer en toegang tot zelfstandige arbeid
-  definition: "1) AI-systemen die bedoeld zijn om te worden gebruikt voor het werven of selecteren van natuurlijke personen, met name voor het plaatsen van gerichte vacatures, het analyseren en filteren van sollicitaties, en het beoordelen van kandidaten\n
-      2) AI-systemen die bedoeld zijn om te worden gebruikt voor het nemen van besluiten die van invloed zijn op de voorwaarden van arbeidsgerelateerde betrekkingen, de bevordering of beëindiging van arbeidsgerelateerde contractuele betrekkingen, voor het toewijzen van taken op basis van individueel gedrag of persoonlijke eigenschappen of kenmerken, of voor het monitoren en evalueren van prestaties en gedrag van personen in dergelijke betrekkingen."
+  definition: "1) AI-systemen die bedoeld zijn om te worden gebruikt voor het werven\
+    \ of selecteren van natuurlijke personen, met name voor het plaatsen van gerichte\
+    \ vacatures, het analyseren en filteren van sollicitaties, en het beoordelen van\
+    \ kandidaten\n 2) AI-systemen die bedoeld zijn om te worden gebruikt voor het\
+    \ nemen van besluiten die van invloed zijn op de voorwaarden van arbeidsgerelateerde\
+    \ betrekkingen, de bevordering of beëindiging van arbeidsgerelateerde contractuele\
+    \ betrekkingen, voor het toewijzen van taken op basis van individueel gedrag of\
+    \ persoonlijke eigenschappen of kenmerken, of voor het monitoren en evalueren\
+    \ van prestaties en gedrag van personen in dergelijke betrekkingen."
 - term: zwevendekommabewerking
-  definition: "Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd door een geheel getal met een vaste precisie, geschaald door een gehele exponent van een vaste basis."
+  definition: Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die
+    een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd
+    door een geheel getal met een vaste precisie, geschaald door een gehele exponent
+    van een vaste basis.
 - term: floating-point operation
-  definition: "Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd door een geheel getal met een vaste precisie, geschaald door een gehele exponent van een vaste basis."
-- term: FLOPs
-  definition: "Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd door een geheel getal met een vaste precisie, geschaald door een gehele exponent van een vaste basis."
-- term: "zwevendekommabewerking of floating-point operation (FLOP)"
-  definition: "Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd door een geheel getal met een vaste precisie, geschaald door een gehele exponent van een vaste basis."
+  definition: Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die
+    een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd
+    door een geheel getal met een vaste precisie, geschaald door een gehele exponent
+    van een vaste basis.
+- term: FLOP
+  definition: Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die
+    een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd
+    door een geheel getal met een vaste precisie, geschaald door een gehele exponent
+    van een vaste basis.
+- term: zwevendekommabewerking of floating-point operation (FLOP)
+  definition: Elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die
+    een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd
+    door een geheel getal met een vaste precisie, geschaald door een gehele exponent
+    van een vaste basis.
 - term: essentiële particuliere en publieke diensten en uitkeringen
-  definition: "1) AI-systemen die bedoeld zijn om door of namens overheidsinstanties te worden gebruikt om te beoordelen of natuurlijke personen in aanmerking komen voor essentiële overheidsuitkeringen en -diensten, waaronder gezondheidsdiensten, of om dergelijke uitkeringen en diensten te verlenen, te beperken, in te trekken of terug te vorderen;\n
-    2) AI-systemen die bedoeld zijn om te worden gebruikt voor het beoordelen van de kredietwaardigheid van natuurlijke personen of voor het vaststellen van hun kredietscore, met uitzondering van AI-systemen die gebruikt worden om financiële fraude op te sporen;\n
-    3) AI-systemen die bedoeld zijn om te worden gebruikt voor risicobeoordeling en prijsstelling met betrekking tot natuurlijke personen in het geval van levens- en ziektekostenverzekeringen;\n
-    4) AI-systemen die bedoeld zijn om noodoproepen van natuurlijke personen te evalueren en te classificeren of om te worden gebruikt voor het inzetten of het bepalen van prioriteiten voor de inzet van hulpdiensten, onder meer van politie, brandweer en ambulance, alsook van systemen voor de triage van patiënten die dringend medische zorg behoeven.\n"
+  definition: "1) AI-systemen die bedoeld zijn om door of namens overheidsinstanties\
+    \ te worden gebruikt om te beoordelen of natuurlijke personen in aanmerking komen\
+    \ voor essentiële overheidsuitkeringen en -diensten, waaronder gezondheidsdiensten,\
+    \ of om dergelijke uitkeringen en diensten te verlenen, te beperken, in te trekken\
+    \ of terug te vorderen;\n 2) AI-systemen die bedoeld zijn om te worden gebruikt\
+    \ voor het beoordelen van de kredietwaardigheid van natuurlijke personen of voor\
+    \ het vaststellen van hun kredietscore, met uitzondering van AI-systemen die gebruikt\
+    \ worden om financiële fraude op te sporen;\n 3) AI-systemen die bedoeld zijn\
+    \ om te worden gebruikt voor risicobeoordeling en prijsstelling met betrekking\
+    \ tot natuurlijke personen in het geval van levens- en ziektekostenverzekeringen;\n\
+    \ 4) AI-systemen die bedoeld zijn om noodoproepen van natuurlijke personen te\
+    \ evalueren en te classificeren of om te worden gebruikt voor het inzetten of\
+    \ het bepalen van prioriteiten voor de inzet van hulpdiensten, onder meer van\
+    \ politie, brandweer en ambulance, alsook van systemen voor de triage van patiënten\
+    \ die dringend medische zorg behoeven.\n"
+- term: AI-bureau
+  definition: De taak van de Commissie waarbij zij bijdraagt aan de uitvoering van,
+    de monitoring van en het toezicht op AI-systemen en AI-modellen voor algemene
+    doeleinden, en AI-governance, als bepaald in het besluit van de Commissie van
+    24 januari 2024; verwijzingen in deze verordening naar het AI-bureau worden begrepen
+    als verwijzingen naar de Commissie
+- term: zwevendekommabewerking of “floating-point operation (FLOP)
+  definition: elke wiskundige bewerking of toewijzing met zwevendekommagetallen, die
+    een subset vormen van de reële getallen die gewoonlijk op computers worden gerepresenteerd
+    door een geheel getal met een vaste precisie, geschaald door een gehele exponent
+    van een vaste basi

--- a/script/convert_definitions_from_AK.py
+++ b/script/convert_definitions_from_AK.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import sys
+from copy import deepcopy
+
+import yaml
+
+
+def parse_markdown_definitions(content: str) -> dict[str, str]:
+    """Parse markdown definition list into a dictionary."""
+    definitions = {}
+    # Pattern matches *[term]: definition
+    pattern = r"\*\[(.*?)\]:\s*(.*?)(?=\*\[|$)"
+    matches = re.finditer(pattern, content, re.DOTALL)
+
+    for match in matches:
+        term = match.group(1).strip()
+        definition = match.group(2).strip()
+        # Clean up definition (remove extra whitespace and newlines)
+        definition = re.sub(r"\s+", " ", definition)
+        definitions[term] = definition
+
+    return definitions
+
+
+def read_yaml_definitions(file_path: str) -> list[dict[str, str]]:
+    """Read existing YAML definitions file."""
+    try:
+        with open(file_path, encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+            if data and "definitions" in data:
+                return data["definitions"]
+    except FileNotFoundError:
+        return []
+    return []
+
+
+def upsert_definitions(existing: list[dict[str, str]], new_defs: dict[str, str]) -> list[dict[str, str]]:
+    """
+    Update existing definitions and insert new ones.
+    Preserves all existing definitions and their order, only updating if new version exists.
+    Appends any new definitions at the end.
+    """
+    # Create a deep copy to avoid modifying the original
+    result = deepcopy(existing)
+
+    # Keep track of terms we've updated
+    updated_terms = set()
+
+    # Update existing definitions
+    for i, item in enumerate(result):
+        term = item["term"]
+        if term in new_defs:
+            if item["definition"] != new_defs[term]:
+                result[i]["definition"] = new_defs[term]
+                print(f"Updated definition for: {term}")
+            updated_terms.add(term)
+
+    # Add new definitions
+    for term, definition in new_defs.items():
+        if term not in updated_terms:
+            result.append({"term": term, "definition": definition})
+            print(f"Added new definition for: {term}")
+
+    return result
+
+
+def write_yaml_definitions(definitions: list[dict[str, str]], output_path: str):
+    """Write definitions to YAML file."""
+    output_data = {"definitions": definitions}
+    with open(output_path, "w", encoding="utf-8") as f:
+        yaml.dump(output_data, f, allow_unicode=True, sort_keys=False, indent=2)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert Markdown definitions to YAML format")
+    parser.add_argument("input_file", help="Input Markdown file path")
+    parser.add_argument("output_file", help="Output YAML file path")
+    args = parser.parse_args()
+
+    # Read input markdown file
+    try:
+        with open(args.input_file, encoding="utf-8") as f:
+            markdown_content = f.read()
+    except FileNotFoundError:
+        print(f"Error: Input file '{args.input_file}' not found")
+        sys.exit(1)
+
+    # Parse markdown definitions
+    new_definitions = parse_markdown_definitions(markdown_content)
+
+    # Read existing YAML definitions
+    existing_definitions = read_yaml_definitions(args.output_file)
+
+    # Perform upsert operation
+    updated_definitions = upsert_definitions(existing_definitions, new_definitions)
+
+    # Write updated definitions to YAML file
+    write_yaml_definitions(updated_definitions, args.output_file)
+
+    print("\nOperation completed:")
+    print(f"Total definitions in output: {len(updated_definitions)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/script/sync
+++ b/script/sync
@@ -1,0 +1,120 @@
+#!/bin/bash
+# support for options in format: --name value
+while [ $# -gt 0 ]; do
+    if [[ $1 == "--"* ]]; then
+        v="${1/--/}"
+        declare "$v"="$2"
+        shift
+    fi
+    shift
+done
+
+REMOTE_BRANCH="${branch:-latest}" # on latest, the last tag is used
+REMOTE_GIT="https://github.com/MinBZK/Algoritmekader.git"
+TMP_DIR="${tmpdir:-tmp-sync}"
+MODE="${mode:-compare}" # use: compare, sync
+VERBOSE="${verbose:-true}"
+
+# Function to check GitHub connectivity
+check_github_access() {
+    if ! curl --silent --head --fail https://github.com > /dev/null; then
+        echo "Warning: Cannot access GitHub. If you're running this in CI/CD:"
+        echo "1. This is expected behavior if running offline"
+        echo "2. The definitions check will be skipped"
+        echo "3. Please run './sync.sh --mode compare' locally before merging"
+        if [ "$MODE" = "compare" ]; then
+            exit 0  # Exit successfully in compare mode
+        else
+            exit 1  # Exit with error in sync mode
+        fi
+    fi
+}
+
+if [ "$VERBOSE" = "true" ]; then
+    printf "This script will compare or sync the status of the Algoritmekader.\n"
+    printf "Settings can be provided using the syntax: --name1 value1 --name2 value2 etc.\n"
+    printf "Current settings:\n"
+    echo "branch: ${REMOTE_BRANCH}"
+    echo "tmpdir: ${TMP_DIR}"
+    echo "mode: ${MODE} (options: compare,sync)"
+    echo "verbose: ${VERBOSE} (options: true,false)"
+    printf "\n\n"
+fi
+
+# Check GitHub access before proceeding
+check_github_access
+
+# Store the root directory
+ROOT_DIR=$(pwd)
+
+# create and use tmp location
+rm -Rf "$TMP_DIR"
+mkdir "$TMP_DIR"
+cd "$TMP_DIR" || exit
+
+if [ "$REMOTE_BRANCH" = "latest" ]; then
+    if ! REMOTE_BRANCH=$(git ls-remote --tags --exit-code --refs --sort="version:refname" "$REMOTE_GIT" | awk -F/ 'END{print$NF}'); then
+        echo "Error: Failed to get latest tag from repository"
+        cd "$ROOT_DIR"
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+fi
+
+# Clone the repository with timeout and retry
+MAX_RETRIES=3
+RETRY_COUNT=0
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if timeout 30 git clone --depth 1 -b "$REMOTE_BRANCH" "$REMOTE_GIT" "algoritmekader"; then
+        break
+    fi
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+        echo "Error: Failed to clone repository after $MAX_RETRIES attempts"
+        cd "$ROOT_DIR"
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+    echo "Retry $RETRY_COUNT of $MAX_RETRIES..."
+    sleep 2
+done
+
+# Ensure root definitions.yaml exists (create empty if needed)
+if [ ! -f "$ROOT_DIR/definitions.yaml" ]; then
+    echo "definitions: []" > "$ROOT_DIR/definitions.yaml"
+fi
+
+# Run the conversion script directly with python
+python3 "$ROOT_DIR/script/convert_definitions_from_AK.py" algoritmekader/includes/begrippenlijst.md "$ROOT_DIR/definitions.yaml"
+if [[ $? -ne 0 ]]; then
+    echo "Error: convert_definitions_from_AK.py failed"
+    cd "$ROOT_DIR"
+    rm -rf "$TMP_DIR"
+    exit 1
+fi
+
+if [ "$MODE" = "compare" ]; then
+    # For compare mode, we need to make a temporary copy to diff against
+    cp "$ROOT_DIR/definitions.yaml" temp_definitions.yaml
+    python3 "$ROOT_DIR/script/convert_definitions_from_AK.py" algoritmekader/includes/begrippenlijst.md temp_definitions.yaml
+    if [ -f "$ROOT_DIR/definitions.yaml" ]; then
+        diff -burN temp_definitions.yaml "$ROOT_DIR/definitions.yaml"
+        exit_status=$?
+        cd "$ROOT_DIR"
+        rm -rf "$TMP_DIR"
+        exit "$exit_status"
+    else
+        echo "Warning: definitions.yaml does not exist in root directory for comparison"
+        cd "$ROOT_DIR"
+        rm -rf "$TMP_DIR"
+        exit 1
+    fi
+fi
+
+# Clean up
+cd "$ROOT_DIR"
+rm -rf "$TMP_DIR"
+
+if [ "$MODE" = "sync" ]; then
+    echo "Successfully synchronized definitions.yaml"
+fi


### PR DESCRIPTION
# Description

In this PR we:
- Make a sync script to catch begrippenlijst.md from Algoritmekader and compare it with the definitions.yaml
- Add definitions with an upsert into the definitions.yaml (as some definitions like FLOP are not 'exactly' like that in the AK) 
- Add a check to the pre-commit if the definitions need to be synced again
- Add handling when GitHub is not accessible in CI environment

Resolves #
